### PR TITLE
added benchmarks as a submodule to Bagel repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "benchmarks"]
+	path = benchmarks
+	url = https://github.com/RENCI-NER/benchmarks.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai==1.30.5
+requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai==1.30.5
 requests==2.32.3
+langchain==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 openai==1.30.5
 requests==2.32.3
 langchain==0.2.1
+langchain-community==0.2.1
+langchain-core==0.2.3
+langchain-text-splitters==0.2.0

--- a/src/bagel.py
+++ b/src/bagel.py
@@ -3,8 +3,8 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 from collections import defaultdict
 
-from comparator.engines.nameres import NameResNEREngine
-from comparator.engines.sapbert import SAPBERTNEREngine
+from benchmarks.comparator.engines.nameres import NameResNEREngine
+from benchmarks.comparator.engines.sapbert import SAPBERTNEREngine
 
 from src.gpt import ask_labels, ask_classes, ask_classes_and_descriptions
 

--- a/src/gpt.py
+++ b/src/gpt.py
@@ -1,4 +1,3 @@
-import base64
 import requests
 import os
 import json
@@ -164,7 +163,13 @@ def ask_labels(text, term, termlist):
 
     for result in results:
         syn = result['synonym']
-        syntype = result['synonymType']
+        if 'synonymType' in result:
+            syntype = result['synonymType']
+        elif 'synonymousType' in result:
+            syntype = result['synonymousType']
+        else:
+            print(f'{result} does not contain synonymType or synonymousType')
+            continue
         curies = labels[syn]
         for curie in curies:
             termlist[curie]["synonym_Type"] = syntype
@@ -201,4 +206,5 @@ def query(prompt):
     content = response.json()["choices"][0]["message"]["content"]
     chunk = content[content.index("["):(content.rindex("]")+1)]
     output = json.loads(chunk)
+
     return output


### PR DESCRIPTION
@YaphetKG @cbizon I added benchmarks from RENCI-NER as a submodule to the Bagel repo which I forked into RENCI-NER as well. I have tested it out locally and it runs for me now without module import issues. I also added a requirements.txt file and added check for the synonymousType key in addition to the synonymType key since chatGPT returns synonymousType for some synonyms for some reason even though the prompt asks chatGPT to return synonymType key explicitly, so I thought it'd be good to check both keys. Take a quick look at the small changes I made to see if they make sense to you.